### PR TITLE
Improve UI integration with backend

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 
 from .config import load_config, save_config
 from .training import train, infer
+from .data.loader import QADataset
 
 
 class Backend:
@@ -81,3 +82,20 @@ class Backend:
         except Exception as exc:  # pragma: no cover - high level
             return {"success": False, "data": None, "error": str(exc)}
         return {"success": True, "data": {"answer": answer}, "error": None}
+
+    def delete_model(self) -> Dict[str, Any]:
+        """Remove saved model file if present."""
+        path = Path("models") / "transformer.pt"
+        try:
+            path.unlink(missing_ok=True)
+        except Exception as exc:  # pragma: no cover - OS level errors
+            return {"success": False, "data": None, "error": str(exc)}
+        return {"success": True, "data": None, "error": None}
+
+    def get_dataset_info(self, data_path: str = ".") -> Dict[str, Any]:
+        """Return basic dataset statistics."""
+        try:
+            ds = QADataset(Path("datas") / data_path)
+        except Exception as exc:  # pragma: no cover - file errors
+            return {"success": False, "data": None, "error": str(exc)}
+        return {"success": True, "data": {"size": len(ds)}, "error": None}

--- a/ui.html
+++ b/ui.html
@@ -561,6 +561,9 @@
             const gpuStatus = document.getElementById('gpuStatus');
             const dropoutInput = document.getElementById('dropoutInput');
             const dropoutValue = document.getElementById('dropoutValue');
+            const deleteBtn = document.getElementById('deleteModelBtn');
+            const deleteStatus = document.getElementById('deleteStatus');
+            const datasetInfo = document.getElementById('datasetInfo');
             const tabs = document.querySelectorAll('.tab');
             const contents = document.querySelectorAll('.content-wrapper');
 
@@ -599,7 +602,9 @@
                 update_config: () => Promise.resolve({}),
                 start_train: () => Promise.resolve(),
                 get_status: () => Promise.resolve({data: {message: 'idle'}}),
-                inference: () => Promise.resolve({data: {answer: ''}})
+                inference: () => Promise.resolve({data: {answer: ''}}),
+                delete_model: () => Promise.resolve(),
+                get_dataset_info: () => Promise.resolve({data: {size: 0}})
             };
 
             api.get_config().then(r => {
@@ -662,6 +667,16 @@
                     .then(() => showStatus(trainStatus, 'saved'))
                     .catch(err => console.error('save failed', err));
             });
+
+            deleteBtn.addEventListener('click', () => {
+                api.delete_model()
+                    .then(() => showStatus(deleteStatus, 'deleted'))
+                    .catch(err => showStatus(deleteStatus, 'error'));
+            });
+
+            api.get_dataset_info('.')
+                .then(r => showStatus(datasetInfo, 'size: ' + r.data.size))
+                .catch(err => console.error('info failed', err));
 
             sendBtn.addEventListener('click', () => {
                 const msg = messageInput.value.trim();


### PR DESCRIPTION
## Summary
- expose dataset and model management APIs in Backend
- show dataset info and enable model deletion from ui.html

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852daa52880832abcfba814ddcd6d21