### PR TITLE
Fix standalone UI training

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Docker, WSL, 또는 기타 가상화 환경을 사용하지 마세요. 프로젝
 
 **If any violation is found, immediately refactor and push again.**
 
+## Running the Application
+
+Run the desktop interface with:
+
+```bash
+python run.py
+```
+
+To use `ui.html` in a regular browser, start the FastAPI server:
+
+```bash
+uvicorn src.app:app --reload
+```
+
+All training and model management features require one of these servers.
+
 ## Environment Variables
 
 - `PYTHONIOENCODING` - default `utf-8`

--- a/scripts/start_api.sh
+++ b/scripts/start_api.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+uvicorn src.app:app --reload

--- a/src/app.py
+++ b/src/app.py
@@ -43,6 +43,18 @@ def status() -> Dict[str, Any]:
     return {"success": True, "data": service.get_status(), "error": None}
 
 
+@app.post("/delete")
+def delete() -> Dict[str, Any]:
+    """Remove current model file."""
+    return service.delete_model()
+
+
+@app.get("/dataset")
+def dataset_info() -> Dict[str, Any]:
+    """Return dataset statistics."""
+    return service.get_dataset_info()
+
+
 class Backend:
     """Used by tests and webview."""
 

--- a/ui.html
+++ b/ui.html
@@ -778,15 +778,20 @@
                 mainContainer.scrollTop = mainContainer.scrollHeight;
             }
 
-            const api = window.pywebview && window.pywebview.api ? window.pywebview.api : {
-                get_config: () => Promise.resolve({data: {}}),
-                update_config: () => Promise.resolve({}),
-                start_training: () => Promise.resolve({msg: 'started'}),
-                get_status: () => Promise.resolve({data: {message: 'idle'}}),
-                inference: (msg) => Promise.resolve({data: {answer: `Echo: ${msg}`}}), // 기본 에코 응답
-                delete_model: () => Promise.resolve(),
-                get_dataset_info: () => Promise.resolve({data: {size: 0}})
-            };
+            const api = window.pywebview && window.pywebview.api ? window.pywebview.api : (() => {
+                const base = 'http://localhost:8000';
+                const j = r => r.json();
+                const post = (url, data) => fetch(base + url, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: data}).then(j);
+                return {
+                    get_config: () => fetch(base + '/config').then(j),
+                    update_config: cfg => post('/config', JSON.stringify(cfg)),
+                    start_training: () => post('/train'),
+                    get_status: () => fetch(base + '/status').then(j),
+                    inference: msg => post('/infer', JSON.stringify({question: msg})),
+                    delete_model: () => post('/delete'),
+                    get_dataset_info: () => fetch(base + '/dataset').then(j)
+                };
+            })();
 
             // 초기 설정 로드
             api.get_config().then(r => {


### PR DESCRIPTION
## Summary
- enable REST API endpoints for deleting models and dataset info
- add HTTP fallback in `ui.html` for non-pywebview usage
- document how to run the FastAPI server or desktop app
- provide a helper script to launch the API server

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c49bd534832aa64a28b470b270cb