### PR TITLE
Fix training flow by removing torch fallbacks

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -72,7 +72,7 @@ class Backend:
         except Exception as exc:
             return {"success": False, "data": None, "error": str(exc)}
 
-    def delete_model(self) -> Dict[str, Any]:
+    def delete_model(self) -> bool:
         return self.svc.delete_model()
 
     def get_dataset_info(self, data_path: str = ".") -> Dict[str, Any]:

--- a/src/ui/backend.py
+++ b/src/ui/backend.py
@@ -18,7 +18,7 @@ class WebBackend:
     def start_training(self) -> Dict[str, Any]:
         return self._svc.start_training()
 
-    def delete_model(self) -> Dict[str, Any]:
+    def delete_model(self) -> bool:
         return self._svc.delete_model()
 
     def infer(self, text: str) -> Dict[str, Any]:

--- a/tests/integration/test_chat_flow.py
+++ b/tests/integration/test_chat_flow.py
@@ -14,4 +14,4 @@ def test_chat_flow(tmp_path):
     res = svc.infer("인공지능이란 뭐야?")
     assert res["success"]
     assert len(res["data"]) >= 5
-    svc.delete_model()
+    assert svc.delete_model() is True

--- a/tests/integration/test_round_trip.py
+++ b/tests/integration/test_round_trip.py
@@ -21,6 +21,6 @@ def test_train_infer_cycle(tmp_path):
     infer_res = backend.infer('인공지능이란 뭐야?')
     assert infer_res['success']
     assert isinstance(infer_res['data'], str)
-    backend.delete_model()
+    assert backend.delete_model() is True
     infer_res2 = backend.infer('인공지능이란 뭐야?')
     assert not infer_res2['success']

--- a/tests/integration/test_training_cycle.py
+++ b/tests/integration/test_training_cycle.py
@@ -10,7 +10,7 @@ def test_training_cycle(tmp_path):
     assert svc.model_path.exists()
     assert svc.model_path.stat().st_size >= 1_000_000
     del_res = svc.delete_model()
-    assert del_res["success"]
+    assert del_res is True
     assert not svc.model_path.exists()
     inf = svc.infer("hi")
     assert not inf["success"]

--- a/tests/integration/test_web_backend.py
+++ b/tests/integration/test_web_backend.py
@@ -19,6 +19,6 @@ def test_web_backend_cycle(tmp_path):
     result = backend.infer('테스트')
     assert result['success']
     assert isinstance(result['data'], str)
-    backend.delete_model()
+    assert backend.delete_model() is True
     result2 = backend.infer('테스트')
     assert not result2['success']

--- a/tests/unit/test_backend.py
+++ b/tests/unit/test_backend.py
@@ -18,6 +18,6 @@ def test_backend_cycle(tmp_path):
             break
         time.sleep(0.1)
     del_res = backend.delete_model()
-    assert del_res['success']
+    assert del_res is True
     inf = backend.infer('hi')
     assert not inf['success']

--- a/ui.html
+++ b/ui.html
@@ -784,7 +784,7 @@
                 start_training: () => Promise.resolve({msg: 'started'}),
                 get_status: () => Promise.resolve({data: {message: 'idle'}}),
                 inference: (msg) => Promise.resolve({data: {answer: `Echo: ${msg}`}}), // 기본 에코 응답
-                delete_model: () => Promise.resolve(),
+                delete_model: () => Promise.resolve(false),
                 get_dataset_info: () => Promise.resolve({data: {size: 0}})
             };
 
@@ -899,12 +899,12 @@
                 clearStatus(trainStatus);
                 clearStatus(deleteStatus);
                 api.delete_model()
-                    .then(r => {
-                        if (r.success) {
-                            showStatus(deleteStatus, r.msg, 'success');
+                    .then(success => {
+                        if (success) {
+                            showStatus(deleteStatus, 'model_deleted', 'success');
                             updateProgress(0, 'idle');
                         } else {
-                            showStatus(deleteStatus, r.msg, 'error');
+                            showStatus(deleteStatus, 'no_model', 'error');
                         }
                     })
                     .catch(err => showStatus(deleteStatus, '모델 파일 삭제 실패: ' + (err.message || err), 'error'));


### PR DESCRIPTION
## Summary
- require torch at import time and use it unconditionally in `training.py`
- validate model save after training
- remove fallback JSON inference
- return boolean for `delete_model` and update backend, UI and tests accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6853c9dbc1f0832a8aef3ea0ac4163c2