### PR TITLE
Enforce torch usage and add training logs

### DIFF
--- a/src/service/core.py
+++ b/src/service/core.py
@@ -78,15 +78,15 @@ class ChatbotService:
                 self._progress = epoch / total
                 self._last_loss = loss
 
-        logger.info("Training %s", path)
+        logger.info("Training started...")
         log_gpu_memory()
         try:
             train(path, self.cfg, progress_cb=progress, model_path=self.model_path)
             if not self.model_path.exists() or self.model_path.stat().st_size < 1_000_000:
-                raise RuntimeError("모델 저장 실패: 파일 미생성 또는 손상")
+                raise RuntimeError("모델 저장 실패: 생성 실패 또는 용량 미달")
             msg = "done"
             self.model_exists = True
-            logger.info("Training finished")
+            logger.info("Training complete")
         except Exception as exc:  # pragma: no cover
             msg = f"error: {exc}"
             logger.exception("Training failed")

--- a/src/training.py
+++ b/src/training.py
@@ -78,6 +78,8 @@ def train(
     save_path = model_path or Path("models") / "current.pth"
     save_path.parent.mkdir(parents=True, exist_ok=True)
 
+    logger.info("Training started...")
+
     if len(ds) < 50:
         logger.warning("Dataset too small: %d entries", len(ds))
     tuner = AutoTuner(len(ds))
@@ -123,7 +125,8 @@ def train(
             break
 
     torch.save(model.state_dict(), save_path)
-    logger.info("Model saved to %s", save_path)
+    logger.info("Model saved to models/current.pth")
+    logger.info("Training complete")
     return save_path
 
 
@@ -158,4 +161,4 @@ def infer(question: str, cfg: Config, model_path: Path | None = None) -> str:
             break
         result.append(words[t - 2])
     out = " ".join(result)
-    return out or "N/A"
+    return out or "No answer"

--- a/src/tuning/auto.py
+++ b/src/tuning/auto.py
@@ -6,10 +6,7 @@ try:
     import psutil  # type: ignore
 except Exception:  # pragma: no cover - optional
     psutil = None
-try:
-    import torch
-except Exception:  # pragma: no cover - optional
-    torch = None
+import torch
 from ..config import Config
 
 
@@ -18,7 +15,7 @@ class AutoTuner:
 
     def __init__(self, dataset_size: int) -> None:
         self.dataset_size = dataset_size
-        if torch is not None and torch.cuda.is_available():
+        if torch.cuda.is_available():
             self.device = "cuda"
         else:
             self.device = "cpu"

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -8,6 +8,7 @@ from logging import Formatter
 from pathlib import Path
 from datetime import datetime
 import json
+import torch
 
 
 LOG_DIR = Path("logs")
@@ -52,11 +53,6 @@ def setup_logger() -> Path:
 
 def log_gpu_memory() -> None:
     """Debug log of current GPU memory usage."""
-    try:
-        import torch
-
-        if torch.cuda.is_available():
-            mem = torch.cuda.memory_allocated() / 1024**2
-            logging.getLogger(__name__).debug("GPU memory %.1fMB", mem)
-    except Exception:
-        logging.getLogger(__name__).debug("GPU memory check failed")
+    if torch.cuda.is_available():
+        mem = torch.cuda.memory_allocated() / 1024**2
+        logging.getLogger(__name__).debug("GPU memory %.1fMB", mem)

--- a/src/utils/vocab.py
+++ b/src/utils/vocab.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
 
-try:
-    import torch  # type: ignore
-except Exception:  # pragma: no cover - optional
-    torch = None
+import torch
 
 from ..data.loader import QADataset
 
@@ -26,8 +23,6 @@ def build_vocab(dataset: QADataset) -> dict[str, int]:
 
 
 def encode(text: str, vocab: dict[str, int]):
-    """Convert text to tensor of token ids or list if torch missing."""
+    """Convert text to tensor of token ids."""
     ids = [vocab.get(t, 0) for t in text.split()] + [vocab["<eos>"]]
-    if torch is None:
-        return ids
     return torch.tensor(ids, dtype=torch.long)


### PR DESCRIPTION
## Summary
- remove optional torch imports and rely on direct import
- log training lifecycle messages
- validate model save with explicit error message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ccb35078832aa654d76c8ace7feb