### PR TITLE
Fix config usage and improve error handling

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Dict
 
 import logging
 import torch
@@ -13,6 +13,7 @@ from torch import nn, optim
 from torch.utils.data import DataLoader, Dataset
 
 from .config import Config
+from .service.utils import to_config
 from .data.loader import QADataset
 from .utils.vocab import build_vocab, encode
 from .model.transformer import Seq2SeqTransformer
@@ -69,11 +70,14 @@ def collate_fn(batch: Iterable[tuple[Any, Any]]):
 
 def train(
     dataset_path: Path,
-    cfg: Config,
+    cfg: Dict[str, Any] | Config,
     progress_cb: Callable | None = None,
     model_path: Path | None = None,
 ) -> Path:
     """Train model using dataset and configuration."""
+    if not isinstance(cfg, Config):
+        cfg = to_config(cfg)
+    assert isinstance(cfg.num_epochs, int) and cfg.num_epochs > 0, "epochs must be int"
     ds = QADataset(dataset_path)
     save_path = model_path or Path("models") / "current.pth"
     save_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/test_epoch_apply.py
+++ b/tests/integration/test_epoch_apply.py
@@ -7,14 +7,9 @@ import time
 def test_epoch_apply(tmp_path):
     setup_logger()
     backend = WebBackend(ChatbotService())
-    backend.set_config({'epochs': 5})
+    backend.set_config({'epochs': 7})
     backend.start_training()
-    found = False
-    for _ in range(60):
-        text = LOG_PATH.read_text(encoding='utf-8')
-        if 'Training complete' in text:
-            found = True
-            break
-        time.sleep(0.1)
+    time.sleep(2)
+    text = LOG_PATH.read_text(encoding='utf-8')
     backend.delete_model()
-    assert found
+    assert 'training epochs=7' in text

--- a/tests/integration/test_infer_error_visible.py
+++ b/tests/integration/test_infer_error_visible.py
@@ -1,0 +1,13 @@
+from src.ui.backend import WebBackend
+from src.service import ChatbotService
+
+def test_infer_error_visible():
+    backend = WebBackend(ChatbotService())
+    captured = {}
+    def show(msg):
+        captured['msg'] = msg
+    # mimic onSend logic
+    res = backend.infer('hello')
+    if not res['success']:
+        show(res['msg'])
+    assert 'model_missing' in captured['msg']

--- a/tests/integration/test_infer_success.py
+++ b/tests/integration/test_infer_success.py
@@ -1,0 +1,16 @@
+import time
+from src.service.core import ChatbotService
+from src.utils.logger import setup_logger
+
+def test_infer_success(tmp_path):
+    setup_logger()
+    svc = ChatbotService()
+    svc.update_config({'epochs': 1})
+    svc.start_training()
+    for _ in range(30):
+        st = svc.get_status()['data']['status_msg']
+        if st == 'done':
+            break
+        time.sleep(0.1)
+    res = svc.infer('안녕')
+    assert res['success'] and len(res['data']) >= 5

--- a/ui.html
+++ b/ui.html
@@ -486,9 +486,10 @@
                 </div>
             <div class="tab" data-tab="settings">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 0 2.4l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1 0-2.4l.15-.1a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>
-                </div>
-        </div>
+    </div>
+    </div>
 
+    <div id="errorBar" class="status-message error" style="display:none"></div>
         <div id="chatContent" class="content-wrapper active">
             <div class="chat-area" id="chatArea">
                 <div class="message bot">
@@ -677,6 +678,13 @@
             function showStatus(el, msg, type = 'info') {
                 el.textContent = msg;
                 el.className = `status-message active ${type}`; // 타입 클래스 추가
+            }
+
+            function showError(msg){
+              const bar = document.getElementById("errorBar");
+              bar.textContent = msg;
+              bar.style.display = "block";
+              setTimeout(()=>bar.style.display='none', 5000);
             }
 
             function clearStatus(el) {
@@ -940,13 +948,13 @@
                 const q = messageInput.value.trim();
                 if (!q) return;
                 api.infer(q).then(({ success, data, msg }) => {
-                    if (!success) { showStatus(trainStatus, msg, 'error'); return; }
+                    if(!success){showError(msg);return;}
                     addMessage(q, 'user');
                     addMessage(data, 'bot');
                     messageInput.value = '';
                     adjustInputHeight();
                     messageInput.focus();
-                }).catch(err => showStatus(trainStatus, err.message || err, 'error'));
+                }).catch(err => showError(err.message || err));
             }
             sendBtn.addEventListener('click', onSend);
 


### PR DESCRIPTION
## Summary
- map config keys correctly when updating configuration
- log epochs before training and log status at inference start
- validate epochs inside training module
- show inference errors in UI via new `errorBar`
- ensure user messages display on success path only
- add integration tests for epoch logging, error visibility and inference success

## Testing
- `pytest -q`
- `pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e5d5ed50832aa8052a3a9fb63e7c