### PR TITLE
Handle empty inference and reduce trainer logs

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -26,6 +26,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "top_k": 10,
     "temperature": 0.7,
     "early_stopping_patience": 5,
+    "verbose": False,
 }
 
 
@@ -45,6 +46,7 @@ class Config:
     top_k: int = 10
     temperature: float = 0.7
     early_stopping_patience: int = 5
+    verbose: bool = False
 
 
 def load_config() -> Dict[str, Any]:

--- a/src/service/loader.py
+++ b/src/service/loader.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from pathlib import Path
+import logging
+import torch
+from ..data.loader import QADataset
+from ..utils.vocab import build_vocab, Tokenizer
+from ..tuning.auto import AutoTuner
+from ..model.transformer import Seq2SeqTransformer
+
+logger = logging.getLogger(__name__)
+
+
+def auto_tune(cfg: dict) -> None:
+    try:
+        ds = QADataset(Path("datas"))
+        sugg = AutoTuner(len(ds)).suggest_config()
+        for k, v in sugg.__dict__.items():
+            if k in cfg:
+                cfg[k] = v
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("Auto tune failed: %s", exc)
+
+
+def load_model(path: Path) -> tuple[Tokenizer, Seq2SeqTransformer]:
+    ds = QADataset(Path("datas"))
+    vocab = build_vocab(ds)
+    tokenizer = Tokenizer(vocab)
+    model = Seq2SeqTransformer(vocab_size=len(vocab))
+    model.load_state_dict(torch.load(path, map_location="cpu"))
+    return tokenizer, model

--- a/src/service/utils.py
+++ b/src/service/utils.py
@@ -18,6 +18,7 @@ _CFG_MAP = {
     'top_k': ('top_k', 10),
     'temperature': ('temperature', 0.7),
     'early_stopping_patience': ('early_stopping_patience', 5),
+    'verbose': ('verbose', False),
 }
 
 def to_config(data: Dict[str, Any]) -> Config:

--- a/src/training.py
+++ b/src/training.py
@@ -119,7 +119,7 @@ def train(
     for epoch in range(params["epochs"]):
         model.train()
         total_loss = 0.0
-        for src, tgt in loader:
+        for step, (src, tgt) in enumerate(loader, start=1):
             src, tgt = src.to(device), tgt.to(device)
             optimizer.zero_grad()
             output = model(src, tgt[:-1, :])
@@ -129,11 +129,14 @@ def train(
             loss.backward()
             optimizer.step()
             total_loss += loss.item()
-        loss_value = total_loss / len(loader)
-        logger.info("Epoch %d loss %.4f", epoch + 1, loss_value)
+            logger.debug("step %d loss %.4f", step, loss.item())
+        epoch_loss = total_loss / len(loader)
+        logger.info(
+            "epoch %d/%d | loss=%.4f", epoch + 1, params["epochs"], epoch_loss
+        )
         if progress_cb:
-            progress_cb(epoch + 1, params["epochs"], loss_value)
-        if stopper.step(loss_value):
+            progress_cb(epoch + 1, params["epochs"], epoch_loss)
+        if stopper.step(epoch_loss):
             logger.info("Early stopping triggered at epoch %d", epoch + 1)
             break
 

--- a/tests/integration/test_empty_answer.py
+++ b/tests/integration/test_empty_answer.py
@@ -1,0 +1,15 @@
+import torch
+from src.service.core import ChatbotService
+from src.utils.vocab import Tokenizer
+
+class DummyModel:
+    def generate(self, *args, **kwargs):
+        return torch.tensor([[1]])
+
+def test_empty_answer():
+    svc = ChatbotService()
+    svc.model_exists = True
+    svc._tokenizer = Tokenizer({"<pad>":0, "<eos>":1})
+    svc._model = DummyModel()
+    res = svc.infer("??")
+    assert not res["success"] and res["msg"] == "empty_answer"

--- a/tests/integration/test_infer_flow_success.py
+++ b/tests/integration/test_infer_flow_success.py
@@ -1,0 +1,16 @@
+import time
+from src.service.core import ChatbotService
+from src.utils.logger import setup_logger
+
+
+def test_infer_flow_success(tmp_path):
+    setup_logger()
+    svc = ChatbotService()
+    svc.update_config({'epochs': 1})
+    svc.start_training()
+    for _ in range(30):
+        if svc.get_status()['data']['status_msg'] == 'done':
+            break
+        time.sleep(0.1)
+    res = svc.infer('안녕')
+    assert res['success'] and len(res['data']) >= 5

--- a/tests/unit/test_log_reduction.py
+++ b/tests/unit/test_log_reduction.py
@@ -1,0 +1,13 @@
+import logging
+from pathlib import Path
+from src.training import train
+from src.config import Config
+
+
+def test_log_reduction(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
+    cfg = Config(num_epochs=1, batch_size=2)
+    train(Path('datas/qa_test_10.json'), cfg, model_path=tmp_path/'m.pth')
+    msgs = [r.message for r in caplog.records]
+    assert any('epoch 1/1' in m for m in msgs)
+    assert not any('step' in m for m in msgs)

--- a/ui.html
+++ b/ui.html
@@ -936,7 +936,10 @@
                 const q = userInput.value.trim();
                 if(!q) return;
                 api.infer(q).then(({success,data,msg})=>{
-                    if(!success){ showError(msg); return; }
+                    if(!success || !data){
+                        showError(msg||'BOT 응답이 비었습니다');
+                        return;
+                    }
                     appendChat('USER', q);
                     appendChat('BOT', data);
                     userInput.value='';


### PR DESCRIPTION
## Summary
- return error if model generates empty answer
- expose verbose mode and log level control
- limit transformer generation and debug logging
- UI now warns when bot reply is empty
- training logs show epoch summary only
- add regression tests for empty answer and log reduction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6853edadf534832ab41c45d1857af46a