### PR TITLE
Remove fallback and ensure diverse answers

### DIFF
--- a/tests/integration/test_empty_answer.py
+++ b/tests/integration/test_empty_answer.py
@@ -12,4 +12,4 @@ def test_empty_answer():
     svc._tokenizer = Tokenizer({"<pad>":0, "<eos>":1})
     svc._model = DummyModel()
     res = svc.infer("??")
-    assert res["success"] and res["data"].startswith("죄송합니다")
+    assert res["success"] and res["data"] == ""

--- a/tests/integration/test_fallback_answer.py
+++ b/tests/integration/test_fallback_answer.py
@@ -14,4 +14,4 @@ def test_fallback_answer():
     svc._tokenizer = Tokenizer({"<pad>":0, "<eos>":1})
     svc._model = DummyModel()
     res = svc.infer("안녕?")
-    assert res["success"] and res["data"].startswith("죄송합니다")
+    assert res["success"] and res["data"] == ""

--- a/tests/unit/test_diverse.py
+++ b/tests/unit/test_diverse.py
@@ -1,0 +1,19 @@
+import torch
+from src.service.core import ChatbotService
+from src.utils.vocab import Tokenizer
+
+class DummyModel:
+    def __init__(self):
+        self.calls = 0
+    def generate(self, *args, **kwargs):
+        self.calls += 1
+        return torch.tensor([[0,2,1]]) if self.calls == 1 else torch.tensor([[0,3,1]])
+
+def test_diverse_outputs():
+    svc = ChatbotService()
+    svc.model_exists = True
+    svc._tokenizer = Tokenizer({"<pad>":0,"<eos>":1,"안녕":2,"하이":3})
+    svc._model = DummyModel()
+    a1 = svc.infer("안녕")['data']
+    a2 = svc.infer("안녕")['data']
+    assert a1 != a2

--- a/tests/unit/test_redundant_block.py
+++ b/tests/unit/test_redundant_block.py
@@ -1,0 +1,15 @@
+import torch
+from src.service.core import ChatbotService
+from src.utils.vocab import Tokenizer
+
+class DummyModel:
+    def generate(self, *args, **kwargs):
+        return torch.tensor([[0,2,3,4,2,3,4,1]])
+
+def test_redundant_block():
+    svc = ChatbotService()
+    svc.model_exists = True
+    svc._tokenizer = Tokenizer({"<pad>":0,"<eos>":1,"위해":2,"꼭":3,"써야":4})
+    svc._model = DummyModel()
+    res = svc.infer("hi")
+    assert res["data"] == "(반복 방지로 내용 제거됨)"

--- a/ui.html
+++ b/ui.html
@@ -227,6 +227,9 @@
             color: var(--color-text-primary);
             margin-right: auto;
         }
+        .bot-msg.blocked {
+            color: var(--color-text-muted);
+        }
 
         .message-footer {
             font-size: 0.75em;
@@ -947,6 +950,9 @@
             function appendChat(role, text){
                 const div = document.createElement('div');
                 div.className = role === 'USER' ? 'user-msg' : 'bot-msg';
+                if(role === 'BOT' && text === '(반복 방지로 내용 제거됨)'){
+                    div.classList.add('blocked');
+                }
                 div.textContent = text;
                 chatHistory.appendChild(div);
                 chatHistory.scrollTop = chatHistory.scrollHeight;
@@ -956,7 +962,7 @@
                 const q = userInput.value.trim();
                 if(!q) return;
                 api.infer(q).then(({success,data,msg})=>{
-                    if(!success || !data){
+                    if(!success){
                         showError(msg||'BOT 응답이 비었습니다');
                         return;
                     }


### PR DESCRIPTION
## Summary
- remove low-quality apology fallback
- block redundant answers
- show blocked message in UI
- keep empty answers visible in UI
- track last few responses
- add tests for redundancy blocking and diverse outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68543babaf24832ab7ce50c95aecd1ab