### PR TITLE
Implement unfiltered responses with multinomial fallback

### DIFF
--- a/tests/unit/test_config_status.py
+++ b/tests/unit/test_config_status.py
@@ -1,0 +1,13 @@
+from src.service.core import ChatbotService
+from pathlib import Path
+import json
+
+def test_update_and_status(tmp_path):
+    svc = ChatbotService()
+    cfg = {"epochs": 3, "batch_size": 2, "lr": 0.001}
+    ok, msg = svc.update_config(cfg)
+    assert ok and msg == "saved"
+    saved = json.load(open(Path("configs/current.json")))
+    assert saved["epochs"] == 3
+    status = svc.get_status()
+    assert status["success"] and "cpu_usage" in status["data"]

--- a/tests/unit/test_multinomial_fallback.py
+++ b/tests/unit/test_multinomial_fallback.py
@@ -1,0 +1,17 @@
+import torch
+from src.model.transformer import Seq2SeqTransformer
+
+class DummyModel(Seq2SeqTransformer):
+    def __init__(self):
+        super().__init__(vocab_size=5)
+    def forward(self, src, tgt):
+        out = torch.full((tgt.size(0), src.size(1), 5), float('-inf'))
+        return out
+
+def test_multinomial_fallback(caplog):
+    model = DummyModel()
+    src = torch.tensor([[0]])
+    out = model.generate(src, max_new_tokens=3)
+    ids = out.view(-1).tolist()[1:]
+    assert ids != []
+    assert any('multinomial fallback used' in r.message for r in caplog.records)

--- a/tests/unit/test_no_filter.py
+++ b/tests/unit/test_no_filter.py
@@ -6,10 +6,10 @@ class DummyModel:
     def generate(self, *args, **kwargs):
         return torch.tensor([[0,2,3,4,2,3,4,1]])
 
-def test_redundant_block():
+def test_no_filter():
     svc = ChatbotService()
     svc.model_exists = True
     svc._tokenizer = Tokenizer({"<pad>":0,"<eos>":1,"위해":2,"꼭":3,"써야":4})
     svc._model = DummyModel()
     res = svc.infer("hi")
-    assert res["data"] == "(반복 방지로 내용 제거됨)"
+    assert res["data"] == "위해 꼭 써야 위해 꼭 써야"

--- a/ui.html
+++ b/ui.html
@@ -227,9 +227,6 @@
             color: var(--color-text-primary);
             margin-right: auto;
         }
-        .bot-msg.blocked {
-            color: var(--color-text-muted);
-        }
 
         .message-footer {
             font-size: 0.75em;
@@ -950,9 +947,6 @@
             function appendChat(role, text){
                 const div = document.createElement('div');
                 div.className = role === 'USER' ? 'user-msg' : 'bot-msg';
-                if(role === 'BOT' && text === '(반복 방지로 내용 제거됨)'){
-                    div.classList.add('blocked');
-                }
                 div.textContent = text;
                 chatHistory.appendChild(div);
                 chatHistory.scrollTop = chatHistory.scrollHeight;


### PR DESCRIPTION
## Summary
- remove redundancy filter logic from `ChatbotService.infer`
- fix `Seq2SeqTransformer.generate` and add multinomial fallback handling
- clean up blocked message style in UI
- add tests for new behaviour and multinomial fallback
- add config/status test for coverage

## Testing
- `pytest -q`
- `pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_e_685441363858832a951e089422a8286c