### PR TITLE
Adjust message order and scroll

### DIFF
--- a/tests/integration/test_auto_scroll.py
+++ b/tests/integration/test_auto_scroll.py
@@ -8,12 +8,12 @@ const { JSDOM } = require('jsdom');
 const dom = new JSDOM('<div id="chatHistory" style="height:120px; overflow:auto"></div>', { runScripts: 'outside-only' });
 const { window } = dom;
 const box = window.document.getElementById('chatHistory');
-new window.MutationObserver(() => { box.scrollTop = box.scrollHeight; }).observe(box, { childList: true });
+new window.MutationObserver(() => { box.scrollTop = 0; }).observe(box, { childList: true });
 function appendChat(role, text){
   const div = window.document.createElement('div');
   div.className = role === 'USER' ? 'user-msg' : 'bot-msg';
   div.textContent = text;
-  box.appendChild(div);
+  box.prepend(div);
 }
 for(let i=0;i<30;i++) appendChat('USER','x'+i);
 console.log(JSON.stringify({ top: box.scrollTop, height: box.scrollHeight, client: box.clientHeight }));
@@ -24,4 +24,4 @@ console.log(JSON.stringify({ top: box.scrollTop, height: box.scrollHeight, clien
 
 def test_auto_scroll():
     res = send_two_messages()
-    assert res['top'] + res['client'] >= res['height'] - 1
+    assert res['top'] == 0

--- a/tests/integration/test_scroll_dom.py
+++ b/tests/integration/test_scroll_dom.py
@@ -8,12 +8,12 @@ const { JSDOM } = require('jsdom');
 const dom = new JSDOM('<div id="chatHistory" style="height:120px; overflow:auto"></div>', { runScripts: 'outside-only' });
 const { window } = dom;
 const box = window.document.getElementById('chatHistory');
-new window.MutationObserver(() => { box.scrollTop = box.scrollHeight; }).observe(box, { childList: true });
+new window.MutationObserver(() => { box.scrollTop = 0; }).observe(box, { childList: true });
 function appendChat(role, text){
   const div = window.document.createElement('div');
   div.className = role === 'USER' ? 'user-msg' : 'bot-msg';
   div.textContent = text;
-  box.appendChild(div);
+  box.prepend(div);
 }
 for(let i=0;i<30;i++) appendChat('USER','m'+i);
 console.log(JSON.stringify({top:box.scrollTop,height:box.scrollHeight,client:box.clientHeight}));
@@ -24,5 +24,5 @@ console.log(JSON.stringify({top:box.scrollTop,height:box.scrollHeight,client:box
 
 def test_scroll_dom():
     res = run_dom_script()
-    assert res['top'] + res['client'] >= res['height'] - 1
+    assert res['top'] == 0
 

--- a/tests/integration/test_scroll_multistep.py
+++ b/tests/integration/test_scroll_multistep.py
@@ -16,11 +16,11 @@ function appendChat(role,text,latency=0){
   meta.className='meta';
   meta.textContent=new Date().toLocaleTimeString()+ ' · '+ latency+' ms';
   divMsg.appendChild(meta);
-  box.appendChild(divMsg);
-  function scrollBottom(){box.scrollTop=box.scrollHeight;}
-  scrollBottom();
-  window.requestAnimationFrame(scrollBottom);
-  window.setTimeout(scrollBottom,30);
+  box.prepend(divMsg);
+  function scrollTop(){box.scrollTop=0;}
+  scrollTop();
+  window.requestAnimationFrame(scrollTop);
+  window.setTimeout(scrollTop,30);
 }
 appendChat('USER','x');
 setTimeout(()=>{console.log(JSON.stringify({top:box.scrollTop,height:box.scrollHeight,client:box.clientHeight}));},40);
@@ -31,4 +31,4 @@ setTimeout(()=>{console.log(JSON.stringify({top:box.scrollTop,height:box.scrollH
 
 def test_scroll_multistep():
     res = run_script()
-    assert res["top"] + res["client"] >= res["height"] - 1
+    assert res["top"] == 0

--- a/tests/integration/test_timestamp_latency.py
+++ b/tests/integration/test_timestamp_latency.py
@@ -16,11 +16,11 @@ function appendChat(role,text,latency=0){
   meta.className='meta';
   meta.textContent=new Date().toLocaleTimeString()+ ' · '+ latency+' ms';
   divMsg.appendChild(meta);
-  box.appendChild(divMsg);
-  function scrollBottom(){box.scrollTop=box.scrollHeight;}
-  scrollBottom();
-  window.requestAnimationFrame(scrollBottom);
-  window.setTimeout(scrollBottom,30);
+  box.prepend(divMsg);
+  function scrollTop(){box.scrollTop=0;}
+  scrollTop();
+  window.requestAnimationFrame(scrollTop);
+  window.setTimeout(scrollTop,30);
 }
 appendChat('BOT','hi',23);
 console.log(JSON.stringify({html:box.innerHTML}));

--- a/ui.html
+++ b/ui.html
@@ -958,15 +958,13 @@
                 meta.className = 'meta';
                 meta.textContent = new Date().toLocaleTimeString() + ' \u00B7 ' + latency + ' ms';
                 divMsg.appendChild(meta);
-                chatHistory.appendChild(divMsg);
+                chatHistory.prepend(divMsg);
 
-                function scrollBottom(){
-                    const box = document.getElementById('chatHistory');
-                    box.scrollTop = box.scrollHeight;
-                }
-                scrollBottom();
-                requestAnimationFrame(scrollBottom);
-                setTimeout(scrollBottom, 30);
+                const box = document.getElementById('chatHistory');
+                function scrollTop(){ box.scrollTop = 0; }
+                scrollTop();
+                requestAnimationFrame(scrollTop);
+                setTimeout(scrollTop, 30);
             }
 
             function onSend(){


### PR DESCRIPTION
## Summary
- prepend new chat messages to top of history
- scroll to top after adding message
- adapt integration tests for new chat order

## Testing
- `pytest tests/integration/test_scroll_dom.py tests/integration/test_auto_scroll.py tests/integration/test_scroll_multistep.py tests/integration/test_timestamp_latency.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685575f0817c832a8a7c049a53f674e4