### PR TITLE
Fix chat history scrolling

### DIFF
--- a/ui.html
+++ b/ui.html
@@ -162,6 +162,7 @@
 
         .chat-history {
             overflow-y: auto;
+            scroll-behavior: smooth;
             height: 100%;
         }
 


### PR DESCRIPTION
## Summary
- keep overflow and add smooth scroll for chat history

## Testing
- `pytest -q tests/integration/test_scroll_dom.py` *(fails: Cannot find module 'jsdom')*
- `pip install torch==2.3.0+cu118 -q` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_685594f9c9c0832aa60f7e02c7a1f616