### PR TITLE
Adjust timestamp layout in chat UI

### DIFF
--- a/tests/integration/test_auto_scroll.py
+++ b/tests/integration/test_auto_scroll.py
@@ -10,10 +10,13 @@ const { window } = dom;
 const box = window.document.getElementById('chatHistory');
 new window.MutationObserver(() => { box.scrollTop = 0; }).observe(box, { childList: true });
 function appendChat(role, text){
-  const div = window.document.createElement('div');
-  div.className = role === 'USER' ? 'user-msg' : 'bot-msg';
-  div.textContent = text;
-  box.prepend(div);
+  const wrap = window.document.createElement('div');
+  wrap.className = role === 'USER' ? 'chat-msg user' : 'chat-msg bot';
+  const bubble = window.document.createElement('div');
+  bubble.className = role === 'USER' ? 'user-msg' : 'bot-msg';
+  bubble.textContent = text;
+  wrap.appendChild(bubble);
+  box.prepend(wrap);
 }
 for(let i=0;i<30;i++) appendChat('USER','x'+i);
 console.log(JSON.stringify({ top: box.scrollTop, height: box.scrollHeight, client: box.clientHeight }));

--- a/tests/integration/test_scroll_dom.py
+++ b/tests/integration/test_scroll_dom.py
@@ -10,10 +10,13 @@ const { window } = dom;
 const box = window.document.getElementById('chatHistory');
 new window.MutationObserver(() => { box.scrollTop = 0; }).observe(box, { childList: true });
 function appendChat(role, text){
-  const div = window.document.createElement('div');
-  div.className = role === 'USER' ? 'user-msg' : 'bot-msg';
-  div.textContent = text;
-  box.prepend(div);
+  const wrap = window.document.createElement('div');
+  wrap.className = role === 'USER' ? 'chat-msg user' : 'chat-msg bot';
+  const bubble = window.document.createElement('div');
+  bubble.className = role === 'USER' ? 'user-msg' : 'bot-msg';
+  bubble.textContent = text;
+  wrap.appendChild(bubble);
+  box.prepend(wrap);
 }
 for(let i=0;i<30;i++) appendChat('USER','m'+i);
 console.log(JSON.stringify({top:box.scrollTop,height:box.scrollHeight,client:box.clientHeight}));

--- a/tests/integration/test_scroll_multistep.py
+++ b/tests/integration/test_scroll_multistep.py
@@ -9,14 +9,18 @@ const { window } = dom;
 const box = window.document.getElementById('chatHistory');
 if(!window.requestAnimationFrame){ window.requestAnimationFrame = cb => setTimeout(cb,16); }
 function appendChat(role,text,latency=0){
-  const divMsg = window.document.createElement('div');
-  divMsg.className = role==='USER'?'user-msg':'bot-msg';
-  divMsg.textContent = text;
-  const meta = window.document.createElement('span');
+  const wrap = window.document.createElement('div');
+  wrap.className = role==='USER'?'chat-msg user':'chat-msg bot';
+  const bubble = window.document.createElement('div');
+  bubble.className = role==='USER'?'user-msg':'bot-msg';
+  bubble.textContent = text;
+  const meta = window.document.createElement('div');
   meta.className='meta';
-  meta.textContent=new Date().toLocaleTimeString()+ ' · '+ latency+' ms';
-  divMsg.appendChild(meta);
-  box.prepend(divMsg);
+  meta.textContent=new Date().toLocaleTimeString();
+  if(role!=='USER') meta.textContent += ' · '+ latency+' ms';
+  wrap.appendChild(bubble);
+  wrap.appendChild(meta);
+  box.prepend(wrap);
   function scrollTop(){box.scrollTop=0;}
   scrollTop();
   window.requestAnimationFrame(scrollTop);

--- a/tests/integration/test_timestamp_latency.py
+++ b/tests/integration/test_timestamp_latency.py
@@ -9,14 +9,18 @@ const { window } = dom;
 const box = window.document.getElementById('chatHistory');
 if(!window.requestAnimationFrame){ window.requestAnimationFrame = cb => setTimeout(cb,16); }
 function appendChat(role,text,latency=0){
-  const divMsg = window.document.createElement('div');
-  divMsg.className = role==='USER'?'user-msg':'bot-msg';
-  divMsg.textContent = text;
-  const meta = window.document.createElement('span');
+  const wrap = window.document.createElement('div');
+  wrap.className = role==='USER'?'chat-msg user':'chat-msg bot';
+  const bubble = window.document.createElement('div');
+  bubble.className = role==='USER'?'user-msg':'bot-msg';
+  bubble.textContent = text;
+  const meta = window.document.createElement('div');
   meta.className='meta';
-  meta.textContent=new Date().toLocaleTimeString()+ ' · '+ latency+' ms';
-  divMsg.appendChild(meta);
-  box.prepend(divMsg);
+  meta.textContent=new Date().toLocaleTimeString();
+  if(role!=='USER') meta.textContent += ' · '+ latency+' ms';
+  wrap.appendChild(bubble);
+  wrap.appendChild(meta);
+  box.prepend(wrap);
   function scrollTop(){box.scrollTop=0;}
   scrollTop();
   window.requestAnimationFrame(scrollTop);

--- a/ui.html
+++ b/ui.html
@@ -210,29 +210,37 @@
             border-bottom-left-radius: var(--border-radius-small);
         }
 
+        .chat-msg {
+            display: flex;
+            flex-direction: column;
+            margin: 50px 0;
+            max-width: 80%;
+        }
+        .chat-msg.user { align-items: flex-end; }
+        .chat-msg.bot { align-items: flex-start; }
+
         .user-msg, .bot-msg {
             padding: 8px 12px;
-            margin: 50px 0;
             border-radius: var(--border-radius-medium);
-            max-width: 80%;
+            display: inline-block;
+            max-width: 100%;
+            word-break: break-word;
         }
 
         .user-msg {
             background: var(--color-accent-primary);
             color: var(--color-text-primary);
-            margin-left: auto;
         }
 
         .bot-msg {
             background: var(--color-background-medium);
             color: var(--color-text-primary);
-            margin-right: auto;
         }
 
         .meta {
             font-size: 0.75rem;
             color: #9ca3af;
-            margin-left: 4px;
+            margin-top: 4px;
         }
 
         .message-footer {
@@ -954,16 +962,23 @@
 
             function appendChat(role, text, latency = 0){
                 messages.push({ role, text, latency });
-                const divMsg = document.createElement('div');
-                divMsg.className = role === 'USER' ? 'user-msg' : 'bot-msg';
-                divMsg.textContent = text;
-                const meta = document.createElement('span');
-                meta.className = 'meta';
-                meta.textContent = new Date().toLocaleTimeString() + ' \u00B7 ' + latency + ' ms';
-                divMsg.appendChild(meta);
-                chatHistory.appendChild(divMsg);
+                const wrap = document.createElement('div');
+                wrap.className = role === 'USER' ? 'chat-msg user' : 'chat-msg bot';
 
-                divMsg.scrollIntoView({ behavior: 'smooth' });
+                const bubble = document.createElement('div');
+                bubble.className = role === 'USER' ? 'user-msg' : 'bot-msg';
+                bubble.textContent = text;
+
+                const meta = document.createElement('div');
+                meta.className = 'meta';
+                meta.textContent = new Date().toLocaleTimeString();
+                if(role !== 'USER') meta.textContent += ' \u00B7 ' + latency + ' ms';
+
+                wrap.appendChild(bubble);
+                wrap.appendChild(meta);
+                chatHistory.appendChild(wrap);
+
+                wrap.scrollIntoView({ behavior: 'smooth' });
             }
 
             function onSend(){


### PR DESCRIPTION
## Summary
- show message timestamp under chat bubbles
- update DOM creation in related integration tests

## Testing
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68559a9932a8832ab0dfd4b5b90e61b2