### PR TITLE
Fix user chat alignment

### DIFF
--- a/ui.html
+++ b/ui.html
@@ -192,7 +192,6 @@
         }
 
         .message.user {
-            margin-left: auto;
             flex-direction: row-reverse;
         }
         .message.user .message-content {
@@ -216,7 +215,13 @@
             margin: 50px 0;
             max-width: 80%;
         }
-        .chat-msg.user { align-items: flex-end; }
+        .chat-msg.user {
+            display: flex;
+            justify-content: flex-end;
+            align-items: flex-end;
+            width: 100%;
+            max-width: 100%;
+        }
         .chat-msg.bot { align-items: flex-start; }
 
         .user-msg, .bot-msg {


### PR DESCRIPTION
## Summary
- align `.chat-msg.user` to screen right
- clean up margin on `.message.user`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68559d0d25b4832aa9ae0683d2e81278