### PR TITLE
Fix retraining flow

### DIFF
--- a/src/service/core.py
+++ b/src/service/core.py
@@ -108,11 +108,8 @@ class ChatbotService:
                 start_ep = 0
             logger.info("resume training from epoch %d", start_ep)
             if start_ep >= epochs:
-                with self._lock:
-                    self.training = False
-                    self._status_msg = "already_trained"
-                    self._progress = 1.0
-                return
+                logger.info("retrain requested; restarting from epoch 0")
+                start_ep = 0
         elif meta_path.exists() and not self.model_path.exists():
             try:
                 meta_path.unlink()

--- a/tests/unit/test_restart_training.py
+++ b/tests/unit/test_restart_training.py
@@ -1,0 +1,20 @@
+import json
+import logging
+from pathlib import Path
+from src.service.core import ChatbotService
+
+
+def test_restart_training(tmp_path, caplog):
+    svc = ChatbotService()
+    svc.model_path = tmp_path / "current.pth"
+    meta = svc.model_path.with_suffix(".meta.json")
+    svc.update_config({"epochs": 1})
+    svc.train(Path("datas"))
+    assert meta.exists()
+    first = json.load(open(meta))
+    assert first["epochs_done"] == 1
+    caplog.set_level(logging.INFO)
+    svc.train(Path("datas"))
+    again = json.load(open(meta))
+    assert again["epochs_done"] == 1
+    assert any("retrain requested" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- allow restarting when epochs already completed
- add unit test covering restart

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6855a516a8c0832aadb0627e543a78d6