### PR TITLE
Fix resume logic to continue epochs

### DIFF
--- a/src/service/core.py
+++ b/src/service/core.py
@@ -100,6 +100,7 @@ class ChatbotService:
         log_gpu_memory()
         meta_path = self.model_path.with_suffix(".meta.json")
         start_ep = 0
+        cfg_local = cfg.copy()
         if self.model_path.exists() and meta_path.exists():
             try:
                 meta = json.load(open(meta_path))
@@ -108,8 +109,10 @@ class ChatbotService:
                 start_ep = 0
             logger.info("resume training from epoch %d", start_ep)
             if start_ep >= epochs:
-                logger.info("retrain requested; restarting from epoch 0")
-                start_ep = 0
+                logger.info(
+                    "continue training for %d more epochs", epochs
+                )
+                cfg_local["epochs"] = start_ep + epochs
         elif meta_path.exists() and not self.model_path.exists():
             try:
                 meta_path.unlink()
@@ -118,7 +121,7 @@ class ChatbotService:
         try:
             train(
                 path,
-                cfg,
+                cfg_local,
                 progress_cb=progress,
                 model_path=self.model_path,
                 start_epoch=start_ep,

--- a/tests/unit/test_restart_training.py
+++ b/tests/unit/test_restart_training.py
@@ -16,5 +16,5 @@ def test_restart_training(tmp_path, caplog):
     caplog.set_level(logging.INFO)
     svc.train(Path("datas"))
     again = json.load(open(meta))
-    assert again["epochs_done"] == 1
-    assert any("retrain requested" in r.message for r in caplog.records)
+    assert again["epochs_done"] == 2
+    assert any("resume training from epoch 1" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- update `ChatbotService.train` to continue training for additional epochs when previous training already matched configured epochs
- adjust restart training test for new behaviour

## Testing
- `pip install torch==2.3.0+cu118 -f https://download.pytorch.org/whl/torch_stable.html`
- `npm install jsdom`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a924463c832a80c576fdbaeab621