### PR TITLE
Add Komoran tokenizer integration

### DIFF
--- a/src/data/morph.py
+++ b/src/data/morph.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Morphological analysis utilities using KoNLPy Komoran."""
+
+import logging
+from typing import List, Dict
+
+try:
+    from konlpy.tag import Komoran
+
+    _komoran = Komoran()
+except Exception as exc:  # pragma: no cover - best effort
+    _komoran = None
+    logging.getLogger(__name__).warning("Komoran init failed: %s", exc)
+
+
+def analyze(text: str) -> List[Dict[str, str]]:
+    """Return list of morphological tokens for ``text``."""
+    if not text:
+        return []
+    if _komoran is None:
+        return [{"text": t, "lemma": t, "pos": "UNK"} for t in text.split()]
+    tokens: List[Dict[str, str]] = []
+    for word, pos in _komoran.pos(text):
+        tokens.append({"text": word, "lemma": word, "pos": pos})
+    return tokens
+
+
+def to_str(tokens: List[Dict[str, str]]) -> str:
+    """Convert token dicts to whitespace joined string."""
+    return " ".join(t.get("lemma") or t.get("text", "") for t in tokens if t)


### PR DESCRIPTION
## Summary
- create `morph.py` implementing Komoran-based morphological analyzer
- rebuild dataset loader to populate token data using analyzer and return token strings for training
- update dependencies for tests

## Testing
- `npm install jsdom`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685654943334832aba0bfac78cd26692