### PR TITLE
Add soynlp support and postprocessing

### DIFF
--- a/src/data/morph.py
+++ b/src/data/morph.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
-"""Morphological analysis utilities using KoNLPy Komoran."""
+"""Morphological analysis utilities using KoNLPy Komoran.
+
+This module normalizes text with ``soynlp`` before analysis and
+applies simple post-processing to remove punctuation tokens.
+"""
 
 import logging
 from typing import List, Dict
+
+from soynlp.normalizer import emoticon_normalize, repeat_normalize
+from soynlp.tokenizer import RegexTokenizer
 
 try:
     from konlpy.tag import Komoran
@@ -13,17 +20,40 @@ except Exception as exc:  # pragma: no cover - best effort
     _komoran = None
     logging.getLogger(__name__).warning("Komoran init failed: %s", exc)
 
+_regex_tokenizer = RegexTokenizer()
+
+
+def _normalize(text: str) -> str:
+    """Return text normalized with ``soynlp`` utilities."""
+    text = emoticon_normalize(text, num_repeats=2)
+    return repeat_normalize(text, num_repeats=2)
+
+
+def _postprocess(tokens: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Remove punctuation tokens."""
+    skip = {"SP", "SSO", "SSC", "SC", "SE", "SF", "SY"}
+    return [t for t in tokens if t.get("pos") not in skip]
+
 
 def analyze(text: str) -> List[Dict[str, str]]:
     """Return list of morphological tokens for ``text``."""
     if not text:
         return []
-    if _komoran is None:
-        return [{"text": t, "lemma": t, "pos": "UNK"} for t in text.split()]
-    tokens: List[Dict[str, str]] = []
-    for word, pos in _komoran.pos(text):
-        tokens.append({"text": word, "lemma": word, "pos": pos})
-    return tokens
+    text = _normalize(text)
+    parts: List[tuple[str, str]]
+    if _komoran is not None:
+        try:
+            parts = _komoran.pos(text)
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.getLogger(__name__).warning("komoran error: %s", exc)
+            parts = [(t, "UNK") for t in _regex_tokenizer.tokenize(text, flatten=True)]
+    else:
+        parts = [(t, "UNK") for t in _regex_tokenizer.tokenize(text, flatten=True)]
+
+    tokens: List[Dict[str, str]] = [
+        {"text": w, "lemma": w, "pos": p} for w, p in parts
+    ]
+    return _postprocess(tokens)
 
 
 def to_str(tokens: List[Dict[str, str]]) -> str:

--- a/tests/unit/test_morph.py
+++ b/tests/unit/test_morph.py
@@ -1,0 +1,7 @@
+from src.data.morph import analyze
+
+
+def test_morph_pipeline():
+    tokens = analyze("안녕, 세계!!! ㅋㅋㅋㅋ")
+    assert tokens
+    assert all(not t['pos'].startswith('S') for t in tokens)


### PR DESCRIPTION
## Summary
- integrate soynlp for normalization and punctuation filtering
- add unit test covering analyze() with new pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565d4e5390832aadfeeb15b272f80e