### PR TITLE
Integrate lemma, pos, domain in encoding

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from .config import Config
 from .service.utils import to_config
 from .data.loader import QADataset
-from .utils.vocab import build_vocab, encode
+from .utils.vocab import build_vocab, encode_tokens, encode
 from .model.transformer import Seq2SeqTransformer
 from .tuning.auto import AutoTuner
 
@@ -55,10 +55,12 @@ class TorchQADataset(Dataset):
         return len(self.data)
 
     def __getitem__(self, idx: int):
-        q, a = self.data[idx]
-        if not q or not a:
+        pair = self.data.pairs[idx]
+        if not pair.tokens_q or not pair.tokens_a:
             raise ValueError("invalid pair")
-        return encode(q, self.vocab), encode(a, self.vocab)
+        q = encode_tokens(pair.tokens_q, pair.concepts, pair.domain, self.vocab)
+        a = encode_tokens(pair.tokens_a, pair.concepts, pair.domain, self.vocab)
+        return q, a
 
 
 def collate_fn(batch: Iterable[tuple[Any, Any]]):

--- a/src/utils/vocab.py
+++ b/src/utils/vocab.py
@@ -1,40 +1,73 @@
 from __future__ import annotations
 
-"""Vocabulary helpers."""
+"""Vocabulary helpers and encoder utilities."""
 
-from pathlib import Path
-from typing import Iterable
-
-from ..data.morph import analyze, to_str
+from typing import Iterable, List, Dict
 
 import torch
 
+from ..data.morph import analyze
 from ..data.loader import QADataset
 
 
+_VALID_POS_PREFIX = ("N", "V", "XR")
+
+
+def _filter_tokens(tokens: List[Dict[str, str]]) -> List[str]:
+    """Return lemmas filtered by POS prefixes."""
+    lemmas: List[str] = []
+    for tok in tokens:
+        pos = tok.get("pos", "")
+        lemma = tok.get("lemma") or tok.get("text", "")
+        if not lemma:
+            continue
+        if any(pos.startswith(p) for p in _VALID_POS_PREFIX):
+            lemmas.append(lemma)
+    return lemmas
+
+
 def build_vocab(dataset: QADataset) -> dict[str, int]:
-    """Create vocabulary dictionary."""
+    """Create vocabulary with domain and concept tokens."""
     tokens: set[str] = set()
-    for q, a in dataset:
-        tokens.update(q.split())
-        tokens.update(a.split())
-    vocab = {t: i + 2 for i, t in enumerate(sorted(tokens))}
+    for pair in dataset.pairs:
+        tokens.update(_filter_tokens(pair.tokens_q))
+        tokens.update(_filter_tokens(pair.tokens_a))
+        tokens.update(pair.concepts)
+        tokens.add(f"[도메인:{pair.domain}]")
+    vocab = {tok: i + 2 for i, tok in enumerate(sorted(tokens))}
     vocab["<pad>"] = 0
     vocab["<eos>"] = 1
     return vocab
 
 
-def encode(text: str, vocab: dict[str, int]) -> torch.Tensor:
-    """Convert raw text to tensor ids using morphological analysis."""
-    morph_tokens = to_str(analyze(text)).split()
-    ids = [vocab.get(t, 0) for t in morph_tokens] + [vocab["<eos>"]]
+def encode_tokens(
+    tokens: List[Dict[str, str]],
+    concepts: List[str],
+    domain: str,
+    vocab: dict[str, int],
+) -> torch.Tensor:
+    """Encode tokens with domain and concepts using ``vocab``."""
+
+    words = _filter_tokens(tokens)
+    for c in concepts:
+        if c not in words:
+            words.append(c)
+    prefix = f"[도메인:{domain}]"
+    seq = [prefix] + words
+    ids = [vocab.get(w, 0) for w in seq] + [vocab["<eos>"]]
     return torch.tensor(ids, dtype=torch.long)
 
 
+def encode(text: str, vocab: dict[str, int]) -> torch.Tensor:
+    """Backward compatible text encoder."""
+    tokens = analyze(text)
+    return encode_tokens(tokens, [], "", vocab)
+
+
 def decode(ids: Iterable[int], vocab: dict[str, int]) -> str:
-    """Convert tensor ids back to string."""
+    """Decode ids back to whitespace joined string."""
     rev = {v: k for k, v in vocab.items()}
-    words = []
+    words: List[str] = []
     for i in ids:
         if i == vocab["<eos>"]:
             break
@@ -45,7 +78,7 @@ def decode(ids: Iterable[int], vocab: dict[str, int]) -> str:
 
 
 class Tokenizer:
-    """Tiny tokenizer built from a dataset."""
+    """Tiny tokenizer with optional rich token input."""
 
     def __init__(self, vocab: dict[str, int]) -> None:
         self.vocab = vocab
@@ -53,5 +86,11 @@ class Tokenizer:
     def encode(self, text: str) -> torch.Tensor:
         return encode(text, self.vocab)
 
+    def encode_tokens(
+        self, tokens: List[Dict[str, str]], concepts: List[str], domain: str
+    ) -> torch.Tensor:
+        return encode_tokens(tokens, concepts, domain, self.vocab)
+
     def decode(self, ids: Iterable[int]) -> str:
         return decode(ids, self.vocab)
+


### PR DESCRIPTION
## Summary
- redesign vocab encoding to accept lemma/POS tokens, domain prefixes and concepts
- build vocabulary with domain and concept tokens
- update training dataset wrapper to use enhanced encoding

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68566b018210832a8fb3f946513ccca1