### PR TITLE
Fix purifier default source

### DIFF
--- a/run_purifier.py
+++ b/run_purifier.py
@@ -10,7 +10,13 @@ from purifier.purifier import clean_file
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Dataset purifier")
-    parser.add_argument("src", type=Path, help="raw dataset file or directory")
+    parser.add_argument(
+        "src",
+        type=Path,
+        nargs="?",
+        default=Path("datas_raw"),
+        help="raw dataset file or directory",
+    )
     parser.add_argument("dst", type=Path, nargs="?", default=Path("datas"), help="output directory")
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- default `run_purifier.py` to look for raw data in `datas_raw`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6856d4877d2c832aa58c8fe13a9c1d62