### PR TITLE
Add simple restore_sentence function

### DIFF
--- a/src/utils/restorer.py
+++ b/src/utils/restorer.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-"""Simple token-based sentence restorer."""
+"""Token-to-sentence restorer based on simple POS rules."""
 
-from typing import List, Dict
+from typing import Dict, List
 
 
 def _has_batchim(word: str) -> bool:
@@ -10,127 +10,35 @@ def _has_batchim(word: str) -> bool:
     if not word:
         return False
     code = ord(word[-1])
-    if 0xAC00 <= code <= 0xD7A3:
-        return (code - 0xAC00) % 28 > 0
-    return False
+    return 0xAC00 <= code <= 0xD7A3 and (code - 0xAC00) % 28 != 0
 
 
-def _ends_with_ao(word: str) -> bool:
-    """Return True if ``word`` ends with ``ㅏ`` or ``ㅗ`` class vowel."""
-    if not word:
-        return False
-    code = ord(word[-1])
-    if 0xAC00 <= code <= 0xD7A3:
-        idx = code - 0xAC00
-        jong = idx % 28
-        jung = ((idx - jong) // 28) % 21
-        return jung in {0, 2, 8, 12}
-    return False
+def _choose_particle(word: str, josa_type: str) -> str:
+    """Return the particle variant for ``word`` based on ``josa_type``."""
+    if josa_type == "JKO":
+        return "을" if _has_batchim(word) else "를"
+    return "은" if _has_batchim(word) else "는"
 
 
-def _should_attach(prev: str, curr: str) -> bool:
-    """Return True if tokens should be concatenated."""
-    if prev.startswith("N") and curr.startswith("J"):
-        return True
-    if prev.startswith("V") and curr.startswith(("E", "X", "V")):
-        return True
-    if prev.startswith("X") and curr.startswith(("J", "E", "V")):
-        return True
-    return False
-
-
-def _clean_tokens(tokens: List[Dict[str, str]]) -> List[Dict[str, str]]:
-    """Remove repeated tokens and long noun sequences."""
-    res: List[Dict[str, str]] = []
-    prev_lemma = ""
-    noun_run = 0
-    for tok in tokens:
-        lemma = tok.get("lemma") or tok.get("text", "")
-        pos = tok.get("pos", "")
-        if not lemma:
-            continue
-        if lemma == prev_lemma:
-            continue
-        if pos.startswith("N"):
-            noun_run += 1
-            if noun_run > 2:
-                continue
-        else:
-            noun_run = 0
-        res.append({"lemma": lemma, "pos": pos})
-        prev_lemma = lemma
-    return res
-
-
-def _combine(tokens: List[Dict[str, str]]) -> List[str]:
-    """Combine tokens into Eojeol words."""
-    if not tokens:
-        return []
+def restore_sentence(tokens: List[Dict[str, str]]) -> str:
+    """Assemble a sentence from morphological tokens."""
     words: List[str] = []
-    prev = tokens[0]
-    buffer = prev["lemma"]
-    for tok in tokens[1:]:
-        lemma = tok["lemma"]
-        pos = tok["pos"]
-        if _should_attach(prev["pos"], pos):
-            buffer += lemma
+    n = len(tokens)
+    for idx, tok in enumerate(tokens):
+        lemma = tok.get("lemma", "")
+        pos = tok.get("pos", "")
+        next_pos = tokens[idx + 1]["pos"] if idx + 1 < n else None
+
+        if pos == "NNG":
+            particle_type = "JKO" if next_pos == "VV" else "JKS"
+            particle = _choose_particle(lemma, particle_type)
+            words.append(lemma + particle)
+        elif pos in {"VV", "VA"}:
+            words.append(lemma + "다")
         else:
-            words.append(buffer)
-            buffer = lemma
-        prev = tok
-    words.append(buffer)
-    return words
+            continue
 
-
-_TEMPLATE_MAP = {
-    "meat": "{N} {V} {A}.",
-    "history": "역사적으로 {N} {V} {A}.",
-    "science": "과학적으로 {N} {V} {A}.",
-    "default": "{N} {V} {A}.",
-}
-
-
-def _select_template(domain: str, concepts: List[str]) -> str:
-    if domain == "고기" or "고기" in concepts:
-        return _TEMPLATE_MAP["meat"]
-    if domain == "역사" or "역사" in concepts:
-        return _TEMPLATE_MAP["history"]
-    if domain == "과학" or "과학" in concepts:
-        return _TEMPLATE_MAP["science"]
-    return _TEMPLATE_MAP["default"]
-
-
-def restore_sentence(tokens: List[Dict[str, str]], concepts: List[str] | None = None, domain: str | None = None) -> str:
-    """Return restored sentence from morphological tokens."""
-    if not tokens:
-        return ""
-    cleaned = _clean_tokens(tokens)
-    words = _combine(cleaned)
-    subject = next((t["lemma"] for t in cleaned if t["pos"].startswith("N")), "")
-    verb = next((t["lemma"] for t in cleaned if t["pos"].startswith("V")), "")
-    adj = next((t["lemma"] for t in cleaned if t["pos"].startswith("VA")), "")
-    if verb == subject:
-        verb = next((t["lemma"] for t in cleaned if t["pos"].startswith("V") and t["lemma"] != subject), verb)
-    if adj in {subject, verb}:
-        adj = next(
-            (t["lemma"] for t in cleaned if t["pos"].startswith("VA") and t["lemma"] not in {subject, verb}),
-            adj,
-        )
-    if not subject:
-        subject = words[0]
-    if not verb:
-        verb = "하"
-    if not adj:
-        adj = "좋"
-    particle = "은" if _has_batchim(subject) else "는"
-    if verb == "하":
-        verb_part = "해야"
-    else:
-        verb_part = verb + ("아야" if _ends_with_ao(verb) else "어야")
-    adj_part = adj + "다"
-    template = _select_template(domain or "", concepts or [])
-    sentence = template.format(N=subject + particle, V=verb_part, A=adj_part)
-    return sentence
+    return " ".join(words)
 
 
 __all__ = ["restore_sentence"]

--- a/tests/unit/test_restorer.py
+++ b/tests/unit/test_restorer.py
@@ -1,114 +1,32 @@
 from src.utils.restorer import restore_sentence
 
-# 10 example token lists
 
-test_inputs = [
-    [
-        {"lemma": "사과", "pos": "NNG"},
-        {"lemma": "는", "pos": "JX"},
-        {"lemma": "몸", "pos": "NNG"},
-        {"lemma": "에", "pos": "JKB"},
-        {"lemma": "좋", "pos": "VA"},
-        {"lemma": "아", "pos": "EF"},
-    ],
-    [
-        {"lemma": "운동", "pos": "NNG"},
-        {"lemma": "을", "pos": "JKO"},
-        {"lemma": "규칙적", "pos": "XR"},
-        {"lemma": "으로", "pos": "JKB"},
-        {"lemma": "하", "pos": "VV"},
-        {"lemma": "아", "pos": "EC"},
-        {"lemma": "건강", "pos": "NNG"},
-        {"lemma": "하", "pos": "XSA"},
-        {"lemma": "아", "pos": "EF"},
-    ],
-    [
-        {"lemma": "책", "pos": "NNG"},
-        {"lemma": "은", "pos": "JX"},
-        {"lemma": "읽", "pos": "VV"},
-        {"lemma": "어야", "pos": "EC"},
-        {"lemma": "지식", "pos": "NNG"},
-        {"lemma": "이", "pos": "JKS"},
-        {"lemma": "늘", "pos": "VV"},
-        {"lemma": "어", "pos": "EF"},
-    ],
-    [
-        {"lemma": "과학", "pos": "NNG"},
-        {"lemma": "은", "pos": "JX"},
-        {"lemma": "실험", "pos": "NNG"},
-        {"lemma": "을", "pos": "JKO"},
-        {"lemma": "통해", "pos": "VV"},
-        {"lemma": "", "pos": "EC"},
-        {"lemma": "발전", "pos": "NNG"},
-        {"lemma": "하", "pos": "XSA"},
-        {"lemma": "아", "pos": "EF"},
-    ],
-    [
-        {"lemma": "음악", "pos": "NNG"},
-        {"lemma": "은", "pos": "JX"},
-        {"lemma": "들", "pos": "VV"},
-        {"lemma": "어야", "pos": "EC"},
-        {"lemma": "마음", "pos": "NNG"},
-        {"lemma": "이", "pos": "JKS"},
-        {"lemma": "편안", "pos": "VA"},
-        {"lemma": "하", "pos": "XSA"},
-        {"lemma": "아", "pos": "EF"},
-    ],
-    [
-        {"lemma": "고기", "pos": "NNG"},
-        {"lemma": "는", "pos": "JX"},
-        {"lemma": "익", "pos": "VV"},
-        {"lemma": "어야", "pos": "EC"},
-        {"lemma": "안전", "pos": "NNG"},
-        {"lemma": "하", "pos": "XSA"},
-        {"lemma": "아", "pos": "EF"},
-    ],
-    [
-        {"lemma": "역사", "pos": "NNG"},
-        {"lemma": "공부", "pos": "NNG"},
-        {"lemma": "는", "pos": "JX"},
-        {"lemma": "계속", "pos": "MAG"},
-        {"lemma": "되", "pos": "VV"},
-        {"lemma": "어야", "pos": "EC"},
-        {"lemma": "이해", "pos": "NNG"},
-        {"lemma": "가", "pos": "JKS"},
-        {"lemma": "깊", "pos": "VA"},
-        {"lemma": "어", "pos": "EF"},
-    ],
-    [
-        {"lemma": "여행", "pos": "NNG"},
-        {"lemma": "은", "pos": "JX"},
-        {"lemma": "계획", "pos": "NNG"},
-        {"lemma": "하", "pos": "XSV"},
-        {"lemma": "아야", "pos": "EC"},
-        {"lemma": "즐겁", "pos": "VA"},
-        {"lemma": "다", "pos": "EF"},
-    ],
-    [
-        {"lemma": "치즈", "pos": "NNG"},
-        {"lemma": "는", "pos": "JX"},
-        {"lemma": "숙성", "pos": "NNG"},
-        {"lemma": "되", "pos": "VV"},
-        {"lemma": "어야", "pos": "EC"},
-        {"lemma": "맛", "pos": "NNG"},
-        {"lemma": "있", "pos": "VA"},
-        {"lemma": "어", "pos": "EF"},
-    ],
-    [
-        {"lemma": "언어", "pos": "NNG"},
-        {"lemma": "는", "pos": "JX"},
-        {"lemma": "연습", "pos": "NNG"},
-        {"lemma": "하", "pos": "XSV"},
-        {"lemma": "아야", "pos": "EC"},
-        {"lemma": "능숙", "pos": "VA"},
-        {"lemma": "하", "pos": "XSA"},
-        {"lemma": "아", "pos": "EF"},
-    ],
-]
-
-
-def test_restore_sentence_examples():
-    for item in test_inputs:
-        out = restore_sentence(item)
-        assert isinstance(out, str)
-        assert out
+def test_restore_sentence_cases():
+    cases = [
+        (
+            [{"lemma": "소고기", "pos": "NNG"}, {"lemma": "익히", "pos": "VV"}],
+            "소고기를 익히다",
+        ),
+        (
+            [{"lemma": "나", "pos": "NNG"}, {"lemma": "피곤하", "pos": "VA"}],
+            "나는 피곤하다",
+        ),
+        (
+            [
+                {"lemma": "학생", "pos": "NNG"},
+                {"lemma": "책", "pos": "NNG"},
+                {"lemma": "읽", "pos": "VV"},
+            ],
+            "학생은 책을 읽다",
+        ),
+        (
+            [{"lemma": "날씨", "pos": "NNG"}, {"lemma": "춥", "pos": "VA"}],
+            "날씨는 춥다",
+        ),
+        (
+            [{"lemma": "사과", "pos": "NNG"}, {"lemma": "맛있", "pos": "VA"}],
+            "사과는 맛있다",
+        ),
+    ]
+    for tokens, expected in cases:
+        assert restore_sentence(tokens) == expected


### PR DESCRIPTION
## Summary
- implement rule-based `restore_sentence` for NNG/VV/VA tokens
- add unit tests covering five token lists

## Testing
- `pytest tests/unit/test_restorer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6856ea44597c832aba07848af569b3e8